### PR TITLE
[codex] Build awesome AirPlay baseline

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## What does this add?
+
+<!-- Describe the AirPlay tool, library, article, or research you are adding. -->
+
+## Checklist
+
+- [ ] The entry is directly related to AirPlay, RAOP, AirPlay 2, or AirPlay-compatible tooling.
+- [ ] The link is reachable and points to the canonical source.
+- [ ] The description explains why the resource is useful.
+- [ ] The description is concise, neutral, and ends with a period.
+- [ ] Commercial, experimental, or historical status is clear when relevant.
+- [ ] I ran `npx awesome-lint`.

--- a/.github/workflows/awesome-lint.yml
+++ b/.github/workflows/awesome-lint.yml
@@ -1,0 +1,18 @@
+name: Awesome Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  awesome-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run awesome-lint
+        run: npx awesome-lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing
+
+Thanks for helping improve Awesome AirPlay.
+
+## Guidelines
+
+- Make sure the item is directly related to AirPlay, RAOP, AirPlay 2, AirPlay-compatible receivers, senders, bridges, debugging, or defensive security research.
+- Prefer projects that are maintained, documented, and useful to someone building or troubleshooting an AirPlay setup.
+- Add one link per pull request when possible.
+- Use this format:
+
+```md
+- [Name](https://example.com/) - Short useful description.
+```
+
+- Keep descriptions concise, neutral, and ending with a period.
+- Put commercial tools in the most relevant section and avoid affiliate links.
+- Put abandoned or mainly historical projects in the Historical Projects section.
+- Do not add piracy, cracked apps, exploit code, or instructions for attacking devices.
+- Check that every link works before opening a pull request.
+
+## Quality Bar
+
+This is a curated list, not a complete directory. A good entry should answer at least one of these questions:
+
+- Does it solve a real AirPlay setup problem?
+- Does it help developers understand or implement the protocol?
+- Does it help users debug discovery, pairing, latency, or streaming issues?
+- Does it document security risks in a responsible, defensive way?
+
+## Running Checks
+
+Run the linter before submitting:
+
+```sh
+npx awesome-lint
+```

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,117 @@
-MIT License
+Creative Commons Legal Code
 
-Copyright (c) 2021 Fedor
+CC0 1.0 Universal
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Statement of Purpose
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator and
+subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for the
+purpose of contributing to a commons of creative, cultural and scientific
+works ("Commons") that the public can reliably and without fear of later
+claims of infringement build upon, modify, incorporate in other works, reuse
+and redistribute as freely as possible in any form whatsoever and for any
+purposes, including without limitation commercial purposes. These owners may
+contribute to the Commons to promote the ideal of a free culture and the
+further production of creative, cultural and scientific works, or to gain
+reputation or greater distribution for their Work in part through the use and
+efforts of others.
+
+For these and/or other purposes and motivations, and without any expectation
+of additional consideration or compensation, the person associating CC0 with a
+Work (the "Affirmer"), to the extent that he or she is an owner of Copyright
+and Related Rights in the Work, voluntarily elects to apply CC0 to the Work
+and publicly distribute the Work under its terms, with knowledge of his or her
+Copyright and Related Rights in the Work and the meaning and intended legal
+effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not limited
+to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display, communicate,
+     and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or likeness
+     depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data in
+     a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation thereof,
+     including any amended or successor version of such directive); and
+vii. other similar, equivalent or corresponding rights throughout the world
+     based on applicable law or treaty, and any national implementations
+     thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention of,
+applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and
+unconditionally waives, abandons, and surrenders all of Affirmer's Copyright
+and Related Rights and associated claims and causes of action, whether now
+known or unknown (including existing as well as future claims and causes of
+action), in the Work (i) in all territories worldwide, (ii) for the maximum
+duration provided by applicable law or treaty (including future time
+extensions), (iii) in any current or future medium and for any number of
+copies, and (iv) for any purpose whatsoever, including without limitation
+commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes
+the Waiver for the benefit of each member of the public at large and to the
+detriment of Affirmer's heirs and successors, fully intending that such Waiver
+shall not be subject to revocation, rescission, cancellation, termination, or
+any other legal or equitable action to disrupt the quiet enjoyment of the Work
+by the public as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason be
+judged legally invalid or ineffective under applicable law, then the Waiver
+shall be preserved to the maximum extent permitted taking into account
+Affirmer's express Statement of Purpose. In addition, to the extent the Waiver
+is so judged Affirmer hereby grants to each affected person a royalty-free,
+non transferable, non sublicensable, non exclusive, irrevocable and
+unconditional license to exercise Affirmer's Copyright and Related Rights in
+the Work (i) in all territories worldwide, (ii) for the maximum duration
+provided by applicable law or treaty (including future time extensions), (iii)
+in any current or future medium and for any number of copies, and (iv) for any
+purpose whatsoever, including without limitation commercial, advertising or
+promotional purposes (the "License"). The License shall be deemed effective as
+of the date CC0 was applied by Affirmer to the Work. Should any part of the
+License for any reason be judged legally invalid or ineffective under
+applicable law, such partial invalidity or ineffectiveness shall not
+invalidate the remainder of the License, and in such case Affirmer hereby
+affirms that he or she will not (i) exercise any of his or her remaining
+Copyright and Related Rights in the Work or (ii) assert any associated claims
+and causes of action with respect to the Work, in either case contrary to
+Affirmer's express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or warranties
+    of any kind concerning the Work, express, implied, statutory or otherwise,
+    including without limitation warranties of title, merchantability, fitness
+    for a particular purpose, non infringement, or the absence of latent or
+    other defects, accuracy, or the present or absence of errors, whether or
+    not discoverable, all to the greatest extent permissible under applicable
+    law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work. Further,
+    Affirmer disclaims responsibility for obtaining any necessary consents,
+    permissions or other rights required for any use of the Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a party
+    to this document and has no duty or obligation with respect to this CC0 or
+    use of the Work.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,104 @@
-# ubuntu-and-airplay
-One page to get information about AirPlay on linux (ubuntu)
+# Awesome AirPlay [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+
+> A curated list of AirPlay receivers, senders, bridges, libraries, protocol notes, debugging tools, and security research.
+
+AirPlay is Apple's wireless media protocol family for audio, video, screen mirroring, and device discovery. This list focuses on practical tools for Linux, Windows, Android, Raspberry Pi, home audio, development, and defensive research.
+
+## Contents
+
+- [Audio Receivers](#audio-receivers)
+- [Screen Mirroring Receivers](#screen-mirroring-receivers)
+- [Senders and Desktop Clients](#senders-and-desktop-clients)
+- [Android](#android)
+- [Bridges and Multiroom](#bridges-and-multiroom)
+- [Linux Audio Stack](#linux-audio-stack)
+- [Libraries and Protocol Implementations](#libraries-and-protocol-implementations)
+- [Debugging and Discovery](#debugging-and-discovery)
+- [Security Research](#security-research)
+- [Protocol Notes](#protocol-notes)
+- [Historical Projects](#historical-projects)
+- [Related Awesome Lists](#related-awesome-lists)
+
+## Audio Receivers
+
+- [Shairport Sync](https://github.com/mikebrady/shairport-sync) - AirPlay and AirPlay 2 audio player for Linux, FreeBSD, and OpenBSD with synchronization, metadata, MQTT, D-Bus, and MPRIS-style integrations.
+- [OwnTone](https://owntone.github.io/owntone-server/) - Open-source media server for GNU/Linux, FreeBSD, and macOS that can stream a local library to AirPlay, Chromecast, Roku, and local audio outputs.
+- [openairplay/airplay2-receiver](https://github.com/openairplay/airplay2-receiver) - Experimental Python AirPlay 2 receiver implementation for protocol study and functional audio receiving.
+- [openairplay/goplay2](https://github.com/openairplay/goplay2) - AirPlay 2 speaker implementation written in Go, useful for studying a smaller receiver codebase.
+- [Airplay.App](https://github.com/natsurainko/Airplay.App) - Windows-focused AirPlay receiver with audio streaming, screen mirroring, and multi-device support.
+
+## Screen Mirroring Receivers
+
+- [UxPlay](https://github.com/FDH2/UxPlay) - Unix AirPlay mirroring server for Linux, macOS, BSD, and Windows, built around GStreamer.
+- [RPiPlay](https://github.com/FD-/RPiPlay) - AirPlay mirroring receiver originally optimized for Raspberry Pi hardware.
+- [java-airplay-server](https://github.com/serezhka/java-airplay-server) - Java AirPlay server that acts like an Apple TV for mirroring experiments.
+- [airplayreceiver](https://github.com/SteeBono/airplayreceiver) - C# implementation of AirPlay 2 mirroring and audio protocol for testing across Windows, macOS, and Linux.
+
+## Senders and Desktop Clients
+
+- [TuneBlade](https://www.tuneblade.com/) - Windows tray utility for streaming system-wide audio to AirPlay receivers, including Apple TV, AirPort Express, AirPlay speakers, and Shairport-based receivers.
+- [AirSend](https://github.com/Pabldi08/AirSend) - Open-source Windows to HomePod AirPlay 2 audio sender written with Rust and Tauri.
+- [pyatv](https://pyatv.dev/) - Python library and CLI for discovering, controlling, and streaming to Apple TV, HomePod, AirPort Express, and AirPlay receivers.
+- [Airfoil](https://rogueamoeba.com/airfoil/mac/) - Commercial macOS and Windows app for routing audio to AirPlay, Bluetooth, Chromecast, Sonos, and local outputs.
+- [AirParrot](https://www.airsquirrels.com/airparrot/) - Commercial desktop screen mirroring and media streaming app for sending to AirPlay, Google Cast, and Miracast receivers.
+
+## Android
+
+- [AirMusic](https://www.airmusic.app/portal/) - Android app for streaming audio from many apps to AirPlay, DLNA, Sonos, Google Cast, HEOS, Fire TV, Roku, and other receivers.
+- [AirScreen](https://www.airscreen.app/) - Android receiver app for AirPlay, Google Cast, Miracast, and DLNA, commonly used on Android TV boxes and Fire TV devices.
+- [AirPin PRO](https://play.google.com/store/apps/details?id=com.waxrain.airplaydmr3) - Android AirPlay and DLNA receiver for phones, tablets, TV boxes, and projectors.
+- [AriaCast Receiver](https://www.music-assistant.io/plugins/ariacast-receiver/) - Music Assistant plugin for receiving high-quality audio streamed from Android devices over an AirPlay-like local path.
+
+## Bridges and Multiroom
+
+- [AirConnect](https://github.com/philippe44/AirConnect) - Bridge that exposes UPnP, Sonos, and Chromecast players as virtual AirPlay devices.
+- [BabelPod](https://github.com/afaden/BabelPod) - Audio relay project for bridging AirPlay, Chromecast, Bluetooth, and local audio devices.
+- [AirSonos](https://github.com/stephen/airsonos) - Historical bridge that made Sonos speakers appear as AirPlay receivers.
+
+## Linux Audio Stack
+
+- [PipeWire RAOP Sink](https://man.archlinux.org/man/extra/pipewire-zeroconf/libpipewire-module-raop-sink.7.en) - PipeWire module for streaming Linux audio to AirPlay devices.
+- [PipeWire RAOP Discover](https://docs.pipewire.org/page_module_raop_discover.html) - PipeWire discovery module for automatically finding AirPlay receivers on the local network.
+- [PipeWire AirPlay Toggle](https://extensions.gnome.org/extension/7652/pipewire-airplay-toggle/) - GNOME Shell extension for toggling PipeWire or PulseAudio AirPlay discovery from Quick Settings.
+- [PulseAudio RAOP Modules](https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/Modules/#module-raop-discover) - PulseAudio modules for discovering and sending audio to RAOP and AirPlay devices.
+
+## Libraries and Protocol Implementations
+
+- [java-airplay-lib](https://github.com/serezhka/java-airplay-lib) - Java library for creating AirPlay 2 servers that behave like Apple TV.
+- [node-appletv](https://github.com/evandcoleman/node-appletv) - Node.js library for controlling Apple TV devices over local network protocols.
+- [AirPlay SDK](https://github.com/xfirefly/Airplay-SDK) - Android and Windows AirPlay receiver SDK with mirroring and casting support.
+- [apsdk-public](https://github.com/air-display/apsdk-public) - C++ AirPlay server implementation for receiver development and protocol reference.
+
+## Debugging and Discovery
+
+- [Avahi](https://www.avahi.org/) - Zeroconf and mDNS implementation used on Linux to discover AirPlay and RAOP services.
+- [Bonjour Browser](https://www.tildesoft.com/) - macOS utility for browsing Bonjour and mDNS services, useful when checking AirPlay advertisements.
+- [Discovery](https://apps.apple.com/us/app/discovery-dns-sd-browser/id305441017) - iOS and macOS DNS-SD browser for inspecting AirPlay, RAOP, and companion services.
+- [Wireshark](https://www.wireshark.org/) - Packet analyzer for inspecting mDNS, RTSP, RTP, HTTP, and TLS traffic around AirPlay sessions.
+- [tcpdump](https://www.tcpdump.org/) - Command-line packet capture tool for recording AirPlay discovery and streaming traffic before deeper analysis.
+
+## Security Research
+
+- [AirBorne by Oligo Security](https://www.oligo.security/blog/airborne) - Research on vulnerabilities in AirPlay and the AirPlay SDK affecting Apple and third-party devices.
+- [Apple Security Releases](https://support.apple.com/en-us/100100) - Official Apple security update index for tracking fixes that may affect AirPlay, tvOS, HomePod, iOS, iPadOS, and macOS.
+- [Apple Platform Security](https://support.apple.com/guide/security/welcome/web) - Apple's security guide for understanding platform controls around local networking, pairing, and media services.
+- [Protocol Prying](https://arxiv.org/abs/2606.26967) - Academic work on reverse engineering and fuzzing proximity transfer protocols such as AirDrop and Quick Share, useful as a methodology reference for closed local-network protocols.
+
+## Protocol Notes
+
+- [Emanuele Cozzi's AirPlay 2 Notes](https://emanuelecozzi.net/docs/airplay2/) - Reverse-engineering notes covering AirPlay 2 receiver behavior and protocol details.
+- [Unofficial AirPlay Protocol Specification](https://nto.github.io/AirPlay.html) - Unofficial documentation of AirPlay and AirTunes behavior.
+- [pyatv AirPlay Stream Documentation](https://pyatv.dev/development/stream/) - Developer notes on pyatv's AirPlay and RAOP streaming support.
+
+## Historical Projects
+
+- [ShairPort](https://github.com/abrasive/shairport) - Original open-source AirPort Express emulator that influenced later AirPlay audio receivers.
+- [ShairPlay](https://github.com/juhovh/shairplay) - Early AirPlay audio server library with FairPlay-related work used by later receiver projects.
+- [playfair](https://github.com/FD-/RPiPlay/tree/master/lib/playfair) - FairPlay-related code bundled in RPiPlay and UxPlay lineage.
+
+## Related Awesome Lists
+
+- [Awesome Home Assistant](https://github.com/frenck/awesome-home-assistant) - Home automation tools and integrations that often overlap with AirPlay, Apple TV, and media routing.
+- [Awesome Self Hosted](https://github.com/awesome-selfhosted/awesome-selfhosted) - Self-hosted services, including media servers and home-network tools.
+- [Awesome Broadcasting](https://github.com/ebu/awesome-broadcasting) - Broadcasting, streaming, audio, and video tooling.
+- [Awesome Audio Visualization](https://github.com/willianjusten/awesome-audio-visualization) - Audio analysis and visualization resources that pair well with media streaming experiments.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ AirPlay is Apple's wireless media protocol family for audio, video, screen mirro
 - [Senders and Desktop Clients](#senders-and-desktop-clients)
 - [Android](#android)
 - [Bridges and Multiroom](#bridges-and-multiroom)
+- [Commercial Receivers](#commercial-receivers)
+- [Hardware and DIY](#hardware-and-diy)
 - [Linux Audio Stack](#linux-audio-stack)
 - [Libraries and Protocol Implementations](#libraries-and-protocol-implementations)
 - [Debugging and Discovery](#debugging-and-discovery)
@@ -33,6 +35,9 @@ AirPlay is Apple's wireless media protocol family for audio, video, screen mirro
 - [RPiPlay](https://github.com/FD-/RPiPlay) - AirPlay mirroring receiver originally optimized for Raspberry Pi hardware.
 - [java-airplay-server](https://github.com/serezhka/java-airplay-server) - Java AirPlay server that acts like an Apple TV for mirroring experiments.
 - [airplayreceiver](https://github.com/SteeBono/airplayreceiver) - C# implementation of AirPlay 2 mirroring and audio protocol for testing across Windows, macOS, and Linux.
+- [AirPlay-Windows](https://github.com/moieric11/AirPlay-Windows) - Native Windows AirPlay 2 receiver for mirroring and RAOP audio without Bonjour SDK or Apple runtime dependencies.
+- [UxPlay-NoBonjour](https://github.com/Kylepossible/uxplay-nobonjour) - Windows-focused UxPlay fork that replaces the Bonjour service dependency with an embedded mDNS responder.
+- [PiP](https://github.com/amitv87/PiP) - macOS picture-in-picture utility with AirPlay receiver support for multiple parallel sessions.
 
 ## Senders and Desktop Clients
 
@@ -47,6 +52,7 @@ AirPlay is Apple's wireless media protocol family for audio, video, screen mirro
 - [AirMusic](https://www.airmusic.app/portal/) - Android app for streaming audio from many apps to AirPlay, DLNA, Sonos, Google Cast, HEOS, Fire TV, Roku, and other receivers.
 - [AirScreen](https://www.airscreen.app/) - Android receiver app for AirPlay, Google Cast, Miracast, and DLNA, commonly used on Android TV boxes and Fire TV devices.
 - [AirPin PRO](https://play.google.com/store/apps/details?id=com.waxrain.airplaydmr3) - Android AirPlay and DLNA receiver for phones, tablets, TV boxes, and projectors.
+- [AirReceiver](https://play.google.com/store/apps/details?id=com.softmedia.receiver) - Android TV and Android box receiver for AirPlay, Google Cast, wireless display, and DLNA.
 - [AriaCast Receiver](https://www.music-assistant.io/plugins/ariacast-receiver/) - Music Assistant plugin for receiving high-quality audio streamed from Android devices over an AirPlay-like local path.
 
 ## Bridges and Multiroom
@@ -54,6 +60,18 @@ AirPlay is Apple's wireless media protocol family for audio, video, screen mirro
 - [AirConnect](https://github.com/philippe44/AirConnect) - Bridge that exposes UPnP, Sonos, and Chromecast players as virtual AirPlay devices.
 - [BabelPod](https://github.com/afaden/BabelPod) - Audio relay project for bridging AirPlay, Chromecast, Bluetooth, and local audio devices.
 - [AirSonos](https://github.com/stephen/airsonos) - Historical bridge that made Sonos speakers appear as AirPlay receivers.
+
+## Commercial Receivers
+
+- [AirServer](https://www.airserver.com/Overview) - Commercial receiver for AirPlay, Google Cast, and Miracast on Windows, macOS, Xbox, Surface Hub, and dedicated hardware.
+- [Reflector](https://www.airsquirrels.com/reflector) - Commercial AirPlay, Google Cast, and Miracast receiver for macOS and Windows with recording and multi-device mirroring.
+- [LonelyScreen](https://www.lonelyscreen.com/) - AirPlay receiver for Windows and macOS focused on iPhone and iPad screen mirroring.
+
+## Hardware and DIY
+
+- [rpi-audio-receiver](https://github.com/nicokaiser/rpi-audio-receiver) - Raspberry Pi audio receiver setup with AirPlay 2, Bluetooth A2DP, and Spotify Connect.
+- [airplay-esp32](https://github.com/rbouteiller/airplay-esp32) - ESP32 and ESP32-S3 AirPlay 2 audio receiver for building low-cost wireless speakers.
+- [raspi-play](https://github.com/N8WM/raspi-play) - Tutorial for building a compact Raspberry Pi Zero 2 W AirPlay 2 audio receiver.
 
 ## Linux Audio Stack
 
@@ -76,6 +94,7 @@ AirPlay is Apple's wireless media protocol family for audio, video, screen mirro
 - [Discovery](https://apps.apple.com/us/app/discovery-dns-sd-browser/id305441017) - iOS and macOS DNS-SD browser for inspecting AirPlay, RAOP, and companion services.
 - [Wireshark](https://www.wireshark.org/) - Packet analyzer for inspecting mDNS, RTSP, RTP, HTTP, and TLS traffic around AirPlay sessions.
 - [tcpdump](https://www.tcpdump.org/) - Command-line packet capture tool for recording AirPlay discovery and streaming traffic before deeper analysis.
+- [Auto Accept AirPlay Requests](https://github.com/duddu/auto-accept-airplay-requests) - macOS helper that automatically accepts AirPlay receiver prompts for trusted local setups.
 
 ## Security Research
 


### PR DESCRIPTION
## Summary

- Replace the placeholder README with a structured Awesome AirPlay list.
- Add researched sections for receivers, senders, Android tools, bridges, commercial receivers, hardware/DIY, Linux audio stack, libraries, debugging, security research, protocol notes, and historical projects.
- Switch the license from MIT to CC0-1.0.
- Add contribution guidelines, a pull request template, and an awesome-lint GitHub Actions workflow.

## Validation

- Ran `NPM_CONFIG_CACHE=/workspace/.npm npx awesome-lint` locally after repository topics were added.
- Ran `git diff --check` locally.
- Ran a README link check with `curl`; all checked URLs returned 200, except Apple's App Store link temporarily returned 429 rate-limit and TuneBlade times out from the container while remaining the official canonical site.

## Research Notes

- Added major commercial receivers: AirServer, Reflector, and LonelyScreen.
- Added Android AirReceiver alongside AirMusic, AirScreen, AirPin PRO, and AriaCast Receiver.
- Added newer open-source receiver/hardware projects: AirPlay-Windows, UxPlay-NoBonjour, PiP, rpi-audio-receiver, airplay-esp32, and raspi-play.